### PR TITLE
Fix/hv transformer pu values

### DIFF
--- a/dataprocessing/sql_snippets/ego_dp_powerflow_osmtgmod_to_pypsa.sql
+++ b/dataprocessing/sql_snippets/ego_dp_powerflow_osmtgmod_to_pypsa.sql
@@ -51,7 +51,7 @@ SELECT
   branch_id AS trafo_id,
   f_bus AS bus0,
   t_bus AS bus1,
-  br_x*100 AS x,
+  br_x/100 AS x,
   rate_a as s_nom,
   tap AS tap_ratio,
   shift AS phase_shift,

--- a/dataprocessing/sql_snippets/ego_dp_powerflow_osmtgmod_to_pypsa.sql
+++ b/dataprocessing/sql_snippets/ego_dp_powerflow_osmtgmod_to_pypsa.sql
@@ -51,7 +51,7 @@ SELECT
   branch_id AS trafo_id,
   f_bus AS bus0,
   t_bus AS bus1,
-  br_x AS x,
+  br_x*100 AS x,
   rate_a as s_nom,
   tap AS tap_ratio,
   shift AS phase_shift,
@@ -76,12 +76,6 @@ UPDATE model_draft.ego_grid_pf_hv_line a
 		b = b * (((SELECT v_nom 
 				FROM model_draft.ego_grid_pf_hv_bus
 				WHERE bus_id=bus1)*1000)^2 / (100 * 10^6));
-
-UPDATE model_draft.ego_grid_pf_hv_transformer a
-	SET 
-		x = x * (((GREATEST(
-				(SELECT v_nom as v_nom_bus0 FROM model_draft.ego_grid_pf_hv_bus WHERE bus_id = bus0), 
-				(SELECT v_nom as v_nom_bus1 FROM model_draft.ego_grid_pf_hv_bus WHERE bus_id = bus1)))* 1000)^2 / (100 * 10^6));
 
 -- calculate line length (in km) from geoms
 


### PR DESCRIPTION
Transformers were using absolute values, even though PyPSA uses per unit values.
Switching from osmtTGmod base of 100 MVA to 1 MVA as used in PyPSA.