### PR TITLE
Feature/versioning line expansion

### DIFF
--- a/dataprocessing/sql_snippets/ego_dp_versioning.sql
+++ b/dataprocessing/sql_snippets/ego_dp_versioning.sql
@@ -394,3 +394,16 @@ INSERT INTO grid.ego_pf_hv_transformer
 
 -- ego scenario log (version,io,schema_name,table_name,script_name,comment)
 SELECT ego_scenario_log('v0.3.0','result','grid','ego_pf_hv_transformer','ego_dp_versioning.sql','versioning');
+
+-- hv pf line expansion cost
+
+/* DELETE FROM grid.ego_line_expansion_costs
+	WHERE	version = 'v0.3.0'; */
+	
+INSERT INTO grid.ego_line_expansion_costs
+	SELECT	'v0.3.0',
+		*
+	FROM	model_draft.ego_grid_line_expansion_costs;
+
+-- ego scenario log (version,io,schema_name,table_name,script_name,comment)
+SELECT ego_scenario_log('v0.3.0','result','grid','ego_line_expansion_costs','ego_dp_versioning.sql','versioning');

--- a/preprocessing/sql_snippets/ego_dp_structure_versioning.sql
+++ b/preprocessing/sql_snippets/ego_dp_structure_versioning.sql
@@ -2492,6 +2492,7 @@ SELECT obj_description('grid.ego_pf_hv_line' ::regclass) ::json;
 -- ego scenario log (version,io,schema_name,table_name,script_name,comment)
 SELECT ego_scenario_log('v0.3.0','result','grid','ego_pf_hv_line','ego_dp_structure_versioning.sql','hv pf lines');
 
+
 -- powerflow link 
 
 -- PF HV link 
@@ -3780,3 +3781,137 @@ SELECT obj_description('grid.ego_pf_hv_transformer' ::regclass) ::json;
 
 -- ego scenario log (version,io,schema_name,table_name,script_name,comment)
 SELECT ego_scenario_log('v0.3.0','result','grid','ego_pf_hv_transformer','ego_dp_structure_versioning.sql','hv pf transformer');
+
+-- line expansion costs 
+/*
+CREATE TABLE grid.ego_line_expansion_costs
+(
+  cost_id bigint NOT NULL,
+  voltage_level text,
+  component text,
+  measure text,
+  investment_cost double precision,
+  unit text,
+  comment text,
+  source text,
+  capital_costs_pypsa double precision,
+  CONSTRAINT ego_line_expansion_costs_pkey PRIMARY KEY (cost_id)
+);
+
+--FK
+ALTER TABLE grid.ego_line_expansion_costs
+	ADD CONSTRAINT ego_line_expansion_costs_fkey FOREIGN KEY (version) 
+	REFERENCES model_draft.ego_scenario(version) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION;
+
+-- grant (oeuser)
+ALTER TABLE	grid.ego_line_expansion_costs OWNER TO oeuser;
+
+*/
+
+-- metadata
+
+COMMENT ON TABLE grid.ego_line_expansion_costs IS '{
+    "title": "eGo power line expansion costs",
+    "description": "Assumption of power line expansion costs for eGo hv powerflow",
+    "language": [ "eng" ],
+    "spatial": {
+        "resolution": "",
+        "location": "",
+        "extend": "Germany"
+    },
+    "temporal": {
+        "reference_date": " ",
+        "start": "",
+        "end": "",
+        "resolution": ""
+    },
+    "sources": [
+        {
+            "url": "https://github.com/openego/data_processing",
+            "copyright": "\\u00a9 ZNES Europ-Universität Flensburg",
+            "name": "eGo dataprocessing",
+            "license": "GNU Affero General Public License Version 3 (AGPL-3.0)",
+            "description": " "
+        },
+        {
+            "url": "https://www.netzentwicklungsplan.de/sites/default/files/paragraphs-files/kostenschaetzungen_nep_2025_1_entwurf.pdf",
+            "copyright": "\\u00a9 50Hertz Transmission GmbH, Amprion GmbH, TenneT TSO GmbH, TransnetBW GmbH",
+            "name": "Netzentwicklungsplan 2015 erster Entwurf",
+            "license": "unknown",
+            "description": " "
+        },
+        {
+            "url": "https://shop.dena.de/sortiment/detail/produkt/dena-verteilnetzstudie-ausbau-und-innovationsbedarf-der-stromverteilnetze-in-deutschland-bis-2030/",
+            "copyright": "\\u00a9 Dena",
+            "name": "dena-Verteilnetzstudie: Ausbau- und Innovationsbedarf der Stromverteilnetze in Deutschland bis 2030",
+            "license": "unknown",
+            "description": " "
+        }
+    ],
+    "license": {
+        "name": "Open Data Commons Open Database License 1.0",
+        "copyright": "\\u00a9 Europa-Universität, Center for Sustainable Energy Systems",
+        "url": "https://opendatacommons.org/licenses/odbl/1.0/",
+        "instruction": "You are free: To Share, To Create, To Adapt; As long as you: Attribute, Share-Alike, Keep open!",
+        "version": "1.0",
+        "id": "ODbL-1.0"
+    },
+    "contributors": [
+        {
+            "date": "2018-01-31",
+            "comment": "Create table",
+            "name": "wolf_bunke",
+            "email": ""
+        }
+    ],
+    "resources": [
+        {
+            "fields": [
+                {
+                    "name": "cost_id",
+                    "unit": "",
+                    "description": "unique id for costs entries"
+                },
+                {
+                    "name": "voltage_level",
+                    "unit": "kV",
+                    "description": "Power voltage level of component"
+                },
+                {
+                    "name": "component",
+                    "unit": " ",
+                    "description": "Name of component"
+                },
+                {
+                    "name": "measure",
+                    "unit": " ",
+                    "description": "measure "
+                },
+				{
+                    "name": "investment_cost",
+                    "unit": "see column unit",
+                    "description": "investment cost of component"
+                },
+				{
+                    "name": "comment",
+                    "unit": "",
+                    "description": "Comment"
+                },
+                {
+                    "name": "source",
+                    "unit": "",
+                    "description": "short name of data source"
+                }
+            ],
+            "name": "grid.ego_line_expansion_costs",
+            "format": "sql"
+        }
+    ],
+    "metadata_version": "1.3"
+}';#
+
+-- select description
+SELECT obj_description('grid.ego_line_expansion_costs' ::regclass) ::json;
+
+-- ego scenario log (version,io,schema_name,table_name,script_name,comment)
+SELECT ego_scenario_log('v0.3.0','result','grid','ego_line_expansion_costs','ego_dp_structure_versioning.sql','hv pf line expansion costs');


### PR DESCRIPTION
I added the table model_draft.ego_grid_line_expansion_costs to the DP versioning. But I'm wondering if this is the right way to handle the versioning of this data set as it is not part of the actual dataprocessing. As far as I understand it is only an input table which does not need to be versioned in every dp run. Am I right?
If yes, I would suggest to store the data only in the grid schema and don't include it in the model_draft. 